### PR TITLE
fix: Unsupported JSON schema type {type_}

### DIFF
--- a/backend/open_webui/utils/schemas.py
+++ b/backend/open_webui/utils/schemas.py
@@ -104,5 +104,9 @@ def json_schema_to_pydantic_type(json_schema: dict[str, Any]) -> Any:
         return Optional[Any]  # Use Optional[Any] for nullable fields
     elif type_ == "literal":
         return Literal[literal_eval(json_schema.get("enum"))]
+    elif type_ == "optional":
+        inner_schema = json_schema.get("items", {"type": "string"})
+        inner_type = json_schema_to_pydantic_type(inner_schema)
+        return Optional[inner_type]
     else:
         raise ValueError(f"Unsupported JSON schema type: {type_}")


### PR DESCRIPTION
I created and working development environment on windows to throughly test this. Worked on dev branch and reopened this pr as you said https://github.com/open-webui/open-webui/pull/5650

checklist passes.

# Changelog Entry

### Description

json_schema_to_pydantic_type gives error on some functions when used by auto_filter and called automatically. this fixes the issue while doesn't change any other case. tested and tried for ootb and customized envrionments.

### Added

added type_ == "optional" for JSON schema support

### Changed

change on schemas.py for JSON support on autofilter calls.

### Deprecated

none

### Removed

none

### Fixed

bug fixed: ValueError: Unsupported JSON schema type: optional

### Security

none

### Breaking Changes

- **BREAKING CHANGE**: none of my tools were working. now they do.


thank you :)
